### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/ffw_joint_trajectory_command_broadcaster/CMakeLists.txt
+++ b/ffw_joint_trajectory_command_broadcaster/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(joint_trajectory_command_broadcaster PUBLIC
 target_link_libraries(joint_trajectory_command_broadcaster PUBLIC
   joint_trajectory_command_broadcaster_parameters
 )
-ament_target_dependencies(joint_trajectory_command_broadcaster PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(joint_trajectory_command_broadcaster PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(joint_trajectory_command_broadcaster PRIVATE "JOINT_TRAJECTORY_COMMAND_BROADCASTER_BUILDING_DLL")

--- a/ffw_joint_trajectory_command_broadcaster/CMakeLists.txt
+++ b/ffw_joint_trajectory_command_broadcaster/CMakeLists.txt
@@ -46,9 +46,8 @@ target_include_directories(joint_trajectory_command_broadcaster PUBLIC
   $<INSTALL_INTERFACE:include/joint_trajectory_command_broadcaster>
 )
 target_link_libraries(joint_trajectory_command_broadcaster PUBLIC
-  joint_trajectory_command_broadcaster_parameters
+  ${builtin_interfaces_TARGETS} ${control_msgs_TARGETS} ${sensor_msgs_TARGETS} ${trajectory_msgs_TARGETS} controller_interface::controller_interface joint_trajectory_command_broadcaster_parameters pluginlib::pluginlib rclcpp_lifecycle::rclcpp_lifecycle rcutils::rcutils realtime_tools::realtime_tools sensor_msgs::sensor_msgs_library urdf::urdf
 )
-target_link_libraries(joint_trajectory_command_broadcaster PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(joint_trajectory_command_broadcaster PRIVATE "JOINT_TRAJECTORY_COMMAND_BROADCASTER_BUILDING_DLL")

--- a/ffw_joystick_controller/CMakeLists.txt
+++ b/ffw_joystick_controller/CMakeLists.txt
@@ -44,9 +44,8 @@ target_include_directories(joystick_controller PUBLIC
   $<INSTALL_INTERFACE:include/joystick_controller>
 )
 target_link_libraries(joystick_controller PUBLIC
-  joystick_controller_parameters
+  ${std_msgs_TARGETS} controller_interface::controller_interface hardware_interface::mock_components joystick_controller_parameters pluginlib::pluginlib rclcpp::rclcpp rclcpp_lifecycle::rclcpp_lifecycle
 )
-target_link_libraries(joystick_controller PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/ffw_joystick_controller/CMakeLists.txt
+++ b/ffw_joystick_controller/CMakeLists.txt
@@ -46,7 +46,7 @@ target_include_directories(joystick_controller PUBLIC
 target_link_libraries(joystick_controller PUBLIC
   joystick_controller_parameters
 )
-ament_target_dependencies(joystick_controller PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(joystick_controller PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/ffw_spring_actuator_controller/CMakeLists.txt
+++ b/ffw_spring_actuator_controller/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories(spring_actuator_controller PUBLIC
 target_link_libraries(spring_actuator_controller PUBLIC
   spring_actuator_controller_parameters
 )
-ament_target_dependencies(spring_actuator_controller PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
+target_link_libraries(spring_actuator_controller PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/ffw_spring_actuator_controller/CMakeLists.txt
+++ b/ffw_spring_actuator_controller/CMakeLists.txt
@@ -53,9 +53,8 @@ target_include_directories(spring_actuator_controller PUBLIC
   $<INSTALL_INTERFACE:include/spring_actuator_controller>
 )
 target_link_libraries(spring_actuator_controller PUBLIC
-  spring_actuator_controller_parameters
+  ${control_msgs_TARGETS} angles::angles control_toolbox::control_toolbox controller_interface::controller_interface hardware_interface::mock_components kdl_parser::kdl_parser pluginlib::pluginlib rclcpp::rclcpp rclcpp_lifecycle::rclcpp_lifecycle realtime_tools::realtime_tools spring_actuator_controller_parameters tl_expected::tl_expected urdf::urdf
 )
-target_link_libraries(spring_actuator_controller PUBLIC ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
