### PR TITLE
add missing header for gcc15

### DIFF
--- a/ffw_robot_manager/include/ffw_robot_manager/battery_model.hpp
+++ b/ffw_robot_manager/include/ffw_robot_manager/battery_model.hpp
@@ -17,6 +17,7 @@
 #ifndef FFW_ROBOT_MANAGER__BATTERY_MODEL_HPP_
 #define FFW_ROBOT_MANAGER__BATTERY_MODEL_HPP_
 
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <utility>

--- a/ffw_robot_manager/include/ffw_robot_manager/ffw_robot_manager.hpp
+++ b/ffw_robot_manager/include/ffw_robot_manager/ffw_robot_manager.hpp
@@ -19,6 +19,7 @@
 
 
 #include <algorithm>
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <unordered_map>

--- a/ffw_robot_manager/include/ffw_robot_manager/ubetter_battery_model.hpp
+++ b/ffw_robot_manager/include/ffw_robot_manager/ubetter_battery_model.hpp
@@ -17,6 +17,7 @@
 #ifndef FFW_ROBOT_MANAGER__UBETTER_BATTERY_MODEL_HPP_
 #define FFW_ROBOT_MANAGER__UBETTER_BATTERY_MODEL_HPP_
 
+#include <cstdint>
 #include <string>
 #include <utility>
 #include "ffw_robot_manager/battery_model.hpp"


### PR DESCRIPTION
fix:
```cpp
[ 57%] Building CXX object CMakeFiles/ffw_robot_manager.dir/src/battery_model.cpp.o
In file included from /build/ai_worker-release-release-jazzy-ffw_robot_manager-1.1.20-1/src/battery_model.cpp:17:
/build/ai_worker-release-release-jazzy-ffw_robot_manager-1.1.20-1/include/ffw_robot_manager/battery_model.hpp:68:11: error: 'uint8_t' does not name a type
   68 |   virtual uint8_t get_power_supply_technology() const = 0;
      |           ^~~~~~~
```