### PR TITLE
fix zenohd alias

### DIFF
--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -69,7 +69,7 @@ RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc  && \
     echo "alias ffw_sh5_follower_ai='ros2 launch ffw_bringup ffw_sh5_follower_ai.launch.py start_rviz:=true use_mock_hardware:=true launch_cameras:=false launch_lidar:=false'" >> ~/.bashrc && \
     echo "alias ffw_bh5_follower_ai='ros2 launch ffw_bringup ffw_bh5_follower_ai.launch.py start_rviz:=true use_mock_hardware:=true launch_cameras:=false launch_lidar:=false'" >> ~/.bashrc && \
     echo "alias ffw_bg2_follower_ai='ros2 launch ffw_bringup ffw_bg2_follower_ai.launch.py start_rviz:=true use_mock_hardware:=true launch_cameras:=false launch_lidar:=false'" >> ~/.bashrc && \
-    echo "alias zenohd='ros2 run zenoh_cpp_daemon zenohd'" >> ~/.bashrc && \
+    echo "alias zenohd='ros2 run rmw_zenoh_cpp rmw_zenohd'" >> ~/.bashrc && \
     echo "export RMW_IMPLEMENTATION=rmw_zenoh_cpp" >> ~/.bashrc && \
     echo "export ROS_DOMAIN_ID=30" >> ~/.bashrc
 

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -165,7 +165,7 @@ RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash" >> ~/.bashrc  && \
     echo "alias ffw_bh5_follower_ai='ros2 launch ffw_bringup ffw_bh5_follower_ai.launch.py'" >> ~/.bashrc && \
     echo "alias motion_controller='ros2 launch cyclo_motion_controller_ros ai_worker_controller.launch.py'" >> ~/.bashrc && \
     echo "alias motion_controller_hand='ros2 launch cyclo_motion_controller_ros ai_worker_controller.launch.py controller_type:=vr hand:=true'" >> ~/.bashrc && \
-    echo "alias zenohd='ros2 run zenoh_cpp_daemon zenohd'" >> ~/.bashrc && \
+    echo "alias zenohd='ros2 run rmw_zenoh_cpp rmw_zenohd'" >> ~/.bashrc && \
     echo "export RMW_IMPLEMENTATION=rmw_zenoh_cpp" >> ~/.bashrc && \
     echo "export ROS_DOMAIN_ID=30" >> ~/.bashrc
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   ai_worker:
     container_name: ai_worker
-    image: robotis/ai-worker:2.0.0
+    image: robotis/ai-worker:2.0.1
     tty: true
     restart: always
     cap_add:

--- a/ffw/CHANGELOG.rst
+++ b/ffw/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ffw
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-06-30)
+------------------
+* Fixed zenohd alias command to run rmw_zenoh_cpp rmw_zenohd
+* Contributors: kimtaehyeong99
+
 2.0.0 (2026-06-17)
 ------------------
 * Set rmw_zenoh_cpp as the default RMW in Docker images

--- a/ffw/package.xml
+++ b/ffw/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ffw</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>
     ROS 2 meta package for FFW
   </description>

--- a/ffw_bringup/CHANGELOG.rst
+++ b/ffw_bringup/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ffw_bringup
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-06-30)
+------------------
+* Fixed zenohd alias command to run rmw_zenoh_cpp rmw_zenohd
+* Contributors: kimtaehyeong99
+
 2.0.0 (2026-06-17)
 ------------------
 * Set rmw_zenoh_cpp as the default RMW in Docker images

--- a/ffw_bringup/package.xml
+++ b/ffw_bringup/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ffw_bringup</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>
     ROS 2 launch scripts for starting the FFW
   </description>

--- a/ffw_bringup/setup.py
+++ b/ffw_bringup/setup.py
@@ -14,7 +14,7 @@ author_emails = ', '.join(email for _, email in authors_info)
 
 setup(
     name=package_name,
-    version='2.0.0',
+    version='2.0.1',
     packages=find_packages(exclude=['test']),
     data_files=[
         ('share/ament_index/resource_index/packages',

--- a/ffw_description/CHANGELOG.rst
+++ b/ffw_description/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ffw_description
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-06-30)
+------------------
+* Fixed zenohd alias command to run rmw_zenoh_cpp rmw_zenohd
+* Contributors: kimtaehyeong99
+
 2.0.0 (2026-06-17)
 ------------------
 * Set rmw_zenoh_cpp as the default RMW in Docker images

--- a/ffw_description/package.xml
+++ b/ffw_description/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ffw_description</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>
     3D models of the FFW for simulation and visualization
   </description>

--- a/ffw_joint_trajectory_command_broadcaster/CHANGELOG.rst
+++ b/ffw_joint_trajectory_command_broadcaster/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ffw_joint_trajectory_command_broadcaster
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-06-30)
+------------------
+* Fixed zenohd alias command to run rmw_zenoh_cpp rmw_zenohd
+* Contributors: kimtaehyeong99
+
 2.0.0 (2026-06-17)
 ------------------
 * Set rmw_zenoh_cpp as the default RMW in Docker images

--- a/ffw_joint_trajectory_command_broadcaster/package.xml
+++ b/ffw_joint_trajectory_command_broadcaster/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ffw_joint_trajectory_command_broadcaster</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>
     Joint Trajectory Command Broadcaster ROS 2 package.
   </description>

--- a/ffw_joystick_controller/CHANGELOG.rst
+++ b/ffw_joystick_controller/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ffw_joystick_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-06-30)
+------------------
+* Fixed zenohd alias command to run rmw_zenoh_cpp rmw_zenohd
+* Contributors: kimtaehyeong99
+
 2.0.0 (2026-06-17)
 ------------------
 * Set rmw_zenoh_cpp as the default RMW in Docker images

--- a/ffw_joystick_controller/package.xml
+++ b/ffw_joystick_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ffw_joystick_controller</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>
     ROS 2 controller for reading joystick values
   </description>

--- a/ffw_moveit_config/CHANGELOG.rst
+++ b/ffw_moveit_config/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ffw_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-06-30)
+------------------
+* Fixed zenohd alias command to run rmw_zenoh_cpp rmw_zenohd
+* Contributors: kimtaehyeong99
+
 2.0.0 (2026-06-17)
 ------------------
 * Set rmw_zenoh_cpp as the default RMW in Docker images

--- a/ffw_moveit_config/package.xml
+++ b/ffw_moveit_config/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ffw_moveit_config</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>
      An automatically generated package with all the configuration and launch files for using the ffw with the MoveIt Motion Planning Framework
   </description>

--- a/ffw_navigation/CHANGELOG.rst
+++ b/ffw_navigation/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ffw_navigation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-06-30)
+------------------
+* Fixed zenohd alias command to run rmw_zenoh_cpp rmw_zenohd
+* Contributors: kimtaehyeong99
+
 2.0.0 (2026-06-17)
 ------------------
 * Set rmw_zenoh_cpp as the default RMW in Docker images

--- a/ffw_navigation/package.xml
+++ b/ffw_navigation/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
 <name>ffw_navigation</name>
-<version>2.0.0</version>
+<version>2.0.1</version>
 <description>ffw_navigation</description>
 <maintainer email="pyo@robotis.com">Pyo</maintainer>
 <license>Apache License 2.0</license>

--- a/ffw_robot_manager/CHANGELOG.rst
+++ b/ffw_robot_manager/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ffw_robot_manager
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-06-30)
+------------------
+* Fixed zenohd alias command to run rmw_zenoh_cpp rmw_zenohd
+* Contributors: kimtaehyeong99
+
 2.0.0 (2026-06-17)
 ------------------
 * Set rmw_zenoh_cpp as the default RMW in Docker images

--- a/ffw_robot_manager/package.xml
+++ b/ffw_robot_manager/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ffw_robot_manager</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>ROS2 controller that logs GPIO Error Code and Hardware Error Status for all GPIO devices.</description>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>
   <license>Apache-2.0</license>

--- a/ffw_spring_actuator_controller/CHANGELOG.rst
+++ b/ffw_spring_actuator_controller/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ffw_spring_actuator_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-06-30)
+------------------
+* Fixed zenohd alias command to run rmw_zenoh_cpp rmw_zenohd
+* Contributors: kimtaehyeong99
+
 2.0.0 (2026-06-17)
 ------------------
 * Set rmw_zenoh_cpp as the default RMW in Docker images

--- a/ffw_spring_actuator_controller/package.xml
+++ b/ffw_spring_actuator_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ffw_spring_actuator_controller</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>
     Spring Actuator Controller ROS 2 package.
   </description>

--- a/ffw_swerve_drive_controller/CHANGELOG.rst
+++ b/ffw_swerve_drive_controller/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ffw_swerve_drive_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-06-30)
+------------------
+* Fixed zenohd alias command to run rmw_zenoh_cpp rmw_zenohd
+* Contributors: kimtaehyeong99
+
 2.0.0 (2026-06-17)
 ------------------
 * Set rmw_zenoh_cpp as the default RMW in Docker images

--- a/ffw_swerve_drive_controller/package.xml
+++ b/ffw_swerve_drive_controller/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ffw_swerve_drive_controller</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>AI Worker's swerve drive ros2_controller</description>
   <maintainer email="pyo@robotis.com">Pyo</maintainer>
   <license>Apache-2.0</license>

--- a/ffw_teleop/CHANGELOG.rst
+++ b/ffw_teleop/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ffw_teleop
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+2.0.1 (2026-06-30)
+------------------
+* Fixed zenohd alias command to run rmw_zenoh_cpp rmw_zenohd
+* Contributors: kimtaehyeong99
+
 2.0.0 (2026-06-17)
 ------------------
 * Set rmw_zenoh_cpp as the default RMW in Docker images

--- a/ffw_teleop/package.xml
+++ b/ffw_teleop/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ffw_teleop</name>
-  <version>2.0.0</version>
+  <version>2.0.1</version>
   <description>
     FFW teleop ROS 2 package.
   </description>

--- a/ffw_teleop/setup.py
+++ b/ffw_teleop/setup.py
@@ -10,7 +10,7 @@ authors = ', '.join(author for author, _ in authors_info)
 author_emails = ', '.join(email for _, email in authors_info)
 setup(
     name=package_name,
-    version='2.0.0',
+    version='2.0.1',
     packages=find_packages(exclude=[]),
     data_files=[
         ('share/ament_index/resource_index/packages',


### PR DESCRIPTION
1. update the zenohd alias command from zenoh_cpp_daemon zenohd to rmw_zenoh_cpp rmw_zenohd
2. bump package versions, changelogs, and Docker Compose image tag to 2.0.1