### PR TITLE
Fix SH5 Gazebo LiDAR/SLAM and RViz configuration issues in description launch files

### DIFF
--- a/ffw_description/gazebo/ffw_sh5_rev1_follower/ffw_sh5_follower.gazebo.xacro
+++ b/ffw_description/gazebo/ffw_sh5_rev1_follower/ffw_sh5_follower.gazebo.xacro
@@ -108,6 +108,69 @@
   <xacro:SimpleTransmission trans="hand_r_trans19" joint="finger_r_joint19" actuator="hand_r_actuator19"/>
   <xacro:SimpleTransmission trans="hand_r_trans20" joint="finger_r_joint20" actuator="hand_r_actuator20"/>
 
+  <!-- GZ lidar sensors for simulation (publish Gazebo LaserScan; bridge to ROS if needed) -->
+  <gazebo reference="lidar_l_link">
+    <sensor name="lidar_left" type="gpu_lidar">
+      <pose>0 0 0 0 0 0</pose>
+      <always_on>true</always_on>
+      <visualize>true</visualize>
+      <update_rate>10.0</update_rate>
+      <ray>
+        <scan>
+          <horizontal>
+            <samples>720</samples>
+            <resolution>1</resolution>
+            <min_angle>-2.356194</min_angle>
+            <max_angle>2.356194</max_angle>
+          </horizontal>
+        </scan>
+        <range>
+          <min>0.05</min>
+          <max>20.0</max>
+          <resolution>0.01</resolution>
+        </range>
+        <noise>
+          <type>gaussian</type>
+          <mean>0.0</mean>
+          <stddev>0.01</stddev>
+        </noise>
+      </ray>
+      <gz_frame_id>lidar_l_link</gz_frame_id>
+      <topic>scan_left</topic>
+    </sensor>
+  </gazebo>
+
+  <gazebo reference="lidar_r_link">
+    <sensor name="lidar_right" type="gpu_lidar">
+      <pose>0 0 0 0 0 0</pose>
+      <always_on>true</always_on>
+      <visualize>true</visualize>
+      <update_rate>10.0</update_rate>
+      <ray>
+        <scan>
+          <horizontal>
+            <samples>720</samples>
+            <resolution>1</resolution>
+            <min_angle>-2.356194</min_angle>
+            <max_angle>2.356194</max_angle>
+          </horizontal>
+        </scan>
+        <range>
+          <min>0.05</min>
+          <max>20.0</max>
+          <resolution>0.01</resolution>
+        </range>
+        <noise>
+          <type>gaussian</type>
+          <mean>0.0</mean>
+          <stddev>0.01</stddev>
+        </noise>
+      </ray>
+      <gz_frame_id>lidar_r_link</gz_frame_id>
+      <topic>scan_right</topic>
+    </sensor>
+  </gazebo>
+
   </xacro:macro>
 
 </robot>

--- a/ffw_description/launch/ffw_bh5_rev1.launch.py
+++ b/ffw_description/launch/ffw_bh5_rev1.launch.py
@@ -55,7 +55,7 @@ def generate_launch_description():
         [
             FindPackageShare('ffw_description'),
             'rviz',
-            'ffw_sh5.rviz'
+            'ffw_bh5.rviz'
         ]
     )
 

--- a/ffw_description/launch/ffw_f2.launch.py
+++ b/ffw_description/launch/ffw_f2.launch.py
@@ -32,6 +32,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     use_gui = LaunchConfiguration('use_gui')
     model = LaunchConfiguration('model')
+    rviz_fixed_frame = LaunchConfiguration('rviz_fixed_frame')
 
     urdf_file = Command(
         [
@@ -55,7 +56,7 @@ def generate_launch_description():
         [
             FindPackageShare('ffw_description'),
             'rviz',
-            'ffw_bg2.rviz'
+            'ffw_f2.rviz'
         ]
     )
 
@@ -70,6 +71,11 @@ def generate_launch_description():
             default_value='ffw_f2_follower',
             description='Robot model name.'),
 
+        DeclareLaunchArgument(
+            'rviz_fixed_frame',
+            default_value='base_link',
+            description='Fixed frame used by RViz.'),
+
         Node(
             package='robot_state_publisher',
             executable='robot_state_publisher',
@@ -79,7 +85,10 @@ def generate_launch_description():
         Node(
             package='rviz2',
             executable='rviz2',
-            arguments=['-d', rviz_config_file],
+            arguments=[
+                '-d', rviz_config_file,
+                '--fixed-frame', rviz_fixed_frame,
+            ],
             output='screen'),
 
         Node(

--- a/ffw_description/launch/ffw_sg2_rev1.launch.py
+++ b/ffw_description/launch/ffw_sg2_rev1.launch.py
@@ -55,7 +55,7 @@ def generate_launch_description():
         [
             FindPackageShare('ffw_description'),
             'rviz',
-            'ffw_bg2.rviz'
+            'ffw_sg2.rviz'
         ]
     )
 

--- a/ffw_description/launch/ffw_sg2_rev1.launch.py
+++ b/ffw_description/launch/ffw_sg2_rev1.launch.py
@@ -32,6 +32,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     use_gui = LaunchConfiguration('use_gui')
     model = LaunchConfiguration('model')
+    rviz_fixed_frame = LaunchConfiguration('rviz_fixed_frame')
 
     urdf_file = Command(
         [
@@ -70,6 +71,11 @@ def generate_launch_description():
             default_value='ffw_sg2_rev1_follower',
             description='Robot model name.'),
 
+        DeclareLaunchArgument(
+            'rviz_fixed_frame',
+            default_value='base_link',
+            description='Fixed frame used by RViz.'),
+
         Node(
             package='robot_state_publisher',
             executable='robot_state_publisher',
@@ -79,7 +85,10 @@ def generate_launch_description():
         Node(
             package='rviz2',
             executable='rviz2',
-            arguments=['-d', rviz_config_file],
+            arguments=[
+                '-d', rviz_config_file,
+                '--fixed-frame', rviz_fixed_frame,
+            ],
             output='screen'),
 
         Node(

--- a/ffw_description/launch/ffw_sh5_rev1.launch.py
+++ b/ffw_description/launch/ffw_sh5_rev1.launch.py
@@ -32,6 +32,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     use_gui = LaunchConfiguration('use_gui')
     model = LaunchConfiguration('model')
+    rviz_fixed_frame = LaunchConfiguration('rviz_fixed_frame')
 
     urdf_file = Command(
         [
@@ -70,6 +71,11 @@ def generate_launch_description():
             default_value='ffw_sh5_rev1_follower',
             description='Robot model name.'),
 
+        DeclareLaunchArgument(
+            'rviz_fixed_frame',
+            default_value='base_link',
+            description='Fixed frame used by RViz.'),
+
         Node(
             package='robot_state_publisher',
             executable='robot_state_publisher',
@@ -79,7 +85,10 @@ def generate_launch_description():
         Node(
             package='rviz2',
             executable='rviz2',
-            arguments=['-d', rviz_config_file],
+            arguments=[
+                '-d', rviz_config_file,
+                '--fixed-frame', rviz_fixed_frame,
+            ],
             output='screen'),
 
         Node(

--- a/ffw_description/rviz/ffw_sh5.rviz
+++ b/ffw_description/rviz/ffw_sh5.rviz
@@ -543,7 +543,7 @@ Visualization Manager:
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
-    Fixed Frame: base_link
+    Fixed Frame: odom
     Frame Rate: 30
   Name: root
   Tools:

--- a/ffw_description/urdf/ffw_sh5_rev1_follower/ffw_sh5_follower.urdf.xacro
+++ b/ffw_description/urdf/ffw_sh5_rev1_follower/ffw_sh5_follower.urdf.xacro
@@ -131,6 +131,7 @@
     <origin xyz="0 0 -0.078" rpy="0 3.14159265359 1.5708"/>
   </joint>
 
+  <xacro:ffw_sh5_follower_gazebo />
   <xacro:hx5_d20_left prefix="$(arg prefix)" />
 
   <joint name="$(arg prefix)hx5_d20_right_joint" type="fixed">


### PR DESCRIPTION
## Summary

Fixes SH5 Gazebo LiDAR output and model-specific RViz/launch configuration issues found during SH5 SLAM and standalone RViz testing.

## 1. SH5 Gazebo SLAM: LiDAR scan topics were not published

LiDAR scan topics were not published, preventing SLAM from generating a map.

**Cause 1** — `lidar_l_link` and `lidar_r_link` were already defined in the URDF, but the SH5 Gazebo xacro did not define any `gpu_lidar` sensors attached to these links.

The sensor output configuration for `scan_left` and `scan_right` was also missing.

→ Added the missing sensor definitions based on the SG2 Gazebo xacro configuration.

**Cause 2** — The `ffw_sh5_follower_gazebo` macro was not called in the SH5 URDF xacro, so the Gazebo settings were not applied to the final `robot_description`.

→ Added the missing macro call.

The ROS-side configuration after the sensor layer was already in place:

- `ffw_bringup/launch/ffw_sh5_follower_ai_gazebo.launch.py` merges `/scan_left` and `/scan_right` into `/scan` using `dual_laser_merger`
- `ffw_bringup/config/common/gz_bridge.yaml` already contains the GZ-to-ROS LaserScan bridge configuration for both topics

## 2. SH5 RViz did not show robot motion

The robot moved correctly in Gazebo, but RViz displayed the robot as stationary because the Fixed Frame was set to `base_link`, which moves together with the robot body.

→ Changed the Fixed Frame in `ffw_sh5.rviz` from `base_link` to `odom`.
`odom -> base_link` 

## 3. Standalone RViz failed to display robot models due to missing `odom` transform

The standalone launch files under `ffw_description` start `robot_state_publisher`, RViz, and `joint_state_publisher_gui`, but do not start the `swerve_drive_controller` or any other node that publishes the `odom` to `base_link` transform.

Therefore, the `odom` frame does not exist.

When RViz loads a configuration with `Fixed Frame: odom` in this state, it reports:
`Fixed Frame [odom] does not exist`

and the robot model is not displayed.

The affected configurations are:

- `ffw_sh5.rviz` — affected by the change in Section 2
- `ffw_sg2.rviz`, `ffw_f2.rviz` — already had the same issue because they used `odom`

→ Added the `rviz_fixed_frame` argument (default: `base_link`) to the three launch files and passed it to RViz using `--fixed-frame`.

The Gazebo bringup launch files start RViz directly with the model-specific RViz configuration and do not apply the standalone override. Therefore, the RViz Fixed Frame remains `odom` when running with Gazebo.

The following configurations were not modified because they already use valid frames:

- `ffw_bg2.rviz` — uses `base_link`
- `ffw_bh5.rviz` — uses `base_link`
- `ffw_f1.rviz` — uses `world`, which exists in the URDF

## 4. Some launch files loaded incorrect RViz configurations

Several launch files were loading RViz configurations from different robot models.

| Launch | Before | After |
|---|---|---|
| `ffw_sg2_rev1.launch.py` | `ffw_bg2.rviz` | `ffw_sg2.rviz` |
| `ffw_f2.launch.py` | `ffw_bg2.rviz` | `ffw_f2.rviz` |
| `ffw_bh5_rev1.launch.py` | `ffw_sh5.rviz` | `ffw_bh5.rviz` |

Since all configuration files existed, the incorrect configurations were loaded without errors.

However, the configurations are not interchangeable:
- Each file uses different Fixed Frame settings.
- Some contain robot link entries that do not exist in the target model.

## Note

This PR does not overlap with `e6b3d5f` ("Added inertial and visual for sh5 lidar links").

That commit adds `<inertial>` and `<visual>` elements to the lidar links, while this PR adds the Gazebo sensor plugins attached to those links.

The two changes complement each other.

## Testing

Tested in the `ai_worker` container on top of the current `main`.

- [x] Verified `/scan_left`, `/scan_right`, and `/scan` publishing
- [x] Verified SH5 SLAM map generation in Gazebo
- [x] Verified robot motion visualization in RViz
- [x] Verified standalone launches load the correct RViz configurations and display robot models:
  - `ffw_sh5_rev1.launch.py`
  - `ffw_sg2_rev1.launch.py`
  - `ffw_f2.launch.py`
  - `ffw_bh5_rev1.launch.py`